### PR TITLE
Don't print the error stack trace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -692,7 +692,8 @@ export function runTasks(config: Config): Promise<void> {
       // reprint the errors
       for (let i = 0; i < err.errors.length; i++) {
         console.log(`Error #${i + 1}`);
-        console.log(err.errors[i]);
+        // only print the error message, not the stack trace
+        console.log(err.errors[i].message);
         console.log();
       }
     });


### PR DESCRIPTION
Because

```
Error #1
84% disk used (over 80%)
```

is nicer than

```
Error #1
Error: 84% disk used (over 80%)
    at Task.function [as task] (/Users/mistewar/src/gh/dotfiles/scripts/good-morning-tasks.ts:360:21)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

I don't need the stack trace, it's cluttering the output with useless information.